### PR TITLE
Stats: May 2019

### DIFF
--- a/2019/cdnjs_May_2019.md
+++ b/2019/cdnjs_May_2019.md
@@ -1,0 +1,147 @@
+# cdnjs May 2019 Usage Stats
+Information provided directly by Cloudflare for the `cdnjs.cloudflare.com` domain. ⛅️
+
+## Key Highlights
+ - This month (May 2019), cdnjs served **over 175 billion requests**. 📈
+ - During May, we used **over 2.9 petabytes of bandwidth** to serve these requests. 📤
+ - That is over **94 terabytes of data and 5.6 billion requests each day**. 🤯
+ - This month, cdnjs consumed only **17 KB of data on average per request**. 🔍
+ 
+### Library Highlights
+ - jQuery (3.3.1) was once again the top library this month, however, the total number of requests was **only 4.8 billion this month, down from 6 billion in April**.
+ - FontAwesome (4.7.0) was, also once again, the next most popular resource this month with **7.5 billion combined requests for the library, up from 6.6 billion last month**.
+ - The jQuery Mouse Wheel plugin (3.1.13) takes third place this month, with **3.4 billion requests for the single file**.
+
+## Total Number of Requests
+> The first important stat for us is the total number of requests sent to cdnjs.cloudflare.com.
+> 
+> Cloudflare provides this number to us at a 1% sample for the whole month, giving 1,646,617,133 at 1%.\
+> This is 164,661,713,300 when multiplied up to 100%.
+> 
+> We are also given a number of requests for 3 days at a 100% sample, which is 17,978,389,499.\
+> This is 185,776,691,490 when recalculated for 31 days.
+
+To provide the best possible estimate for the entire month, an average of both numbers will be used to generate the estimate for the final number of requests for the month.\
+This results in cdnjs serving 175,219,202,395 requests in May as an estimate.
+
+**Over 175 billion requests this month or 5.6 billion requests every day**. 📈
+
+## Total Bandwidth Usage
+> Another great stat that Cloudflare have given us this month is the bandwidth usage for the cdnjs.cloudflare.com domain.
+> 
+> Once again, this number is provided at a 1% sample for the month and in gigabytes: 27,535.92 GB.\
+> This is 2,753,592 GB or 2.75 PB when multiplied up to be 100%.
+> 
+> Additionally, as with the request count, a 3 day 100% sample is given by Cloudflare at 299,798.52 GB.\
+> This results in 3,097,918.04 GB or 3.1 PB for the month.
+
+As with the total number of requests, both numbers will be used with an average being the final estimate for the bandwidth consumed this month.\
+This produces the estimate of 2,925,755.02 GB of bandwidth used for this month.
+
+**This gives us a massive 2.9 petabytes of bandwidth used for cdnjs requests in May**. 🤯
+
+## Top 100 Requested Resources
+> These are provided at a 1% sample for the month of May. Bandwidth is measured in gigabytes.
+
+| # | Requests | Bandwidth | cdnjs Resource URL |
+|---|----------|-----------|--------------------|
+| 1   | 48,176,628 | 1,168.13 | [cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js)                                                           |
+| 2   | 40,167,096 |   258.71 | [cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css](https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css)                         |
+| 3   | 34,181,171 |    58.44 | [cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js)             |
+| 4   | 29,527,055 | 2,060.83 | [cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/fonts/fontawesome-webfont.woff2](https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/fonts/fontawesome-webfont.woff2)           |
+| 5   | 20,732,329 |   683.82 | [cdnjs.cloudflare.com/ajax/libs/gsap/latest/TweenMax.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/latest/TweenMax.min.js)                                                         |
+| 6   | 18,891,576 |    29.29 | [cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.css](https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.css)                           |
+| 7   | 18,636,779 |   119.29 | [cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.js](https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.js)                             |
+| 8   | 15,341,465 |   469.14 | [cdnjs.cloudflare.com/ajax/libs/jquery/1.6.1/jquery.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery/1.6.1/jquery.min.js)                                                           |
+| 9   | 13,564,961 |    16.10 | [cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js)                               |
+| 10  | 11,311,235 |   395.91 | [cdnjs.cloudflare.com/ajax/libs/gsap/1.19.1/TweenMax.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/1.19.1/TweenMax.min.js)                                                         |
+| 11  | 10,767,862 |    41.86 | [cdnjs.cloudflare.com/ajax/libs/json3/3.3.2/json3.min.js](https://cdnjs.cloudflare.com/ajax/libs/json3/3.3.2/json3.min.js)                                                               |
+| 12  | 10,262,889 |    17.75 | [cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.12/jquery.mousewheel.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.12/jquery.mousewheel.min.js)             |
+| 13  | 9,508,889  |   265.54 | [cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js)                                                           |
+| 14  | 9,304,254  |   331.82 | [cdnjs.cloudflare.com/ajax/libs/gsap/2.0.2/TweenMax.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/2.0.2/TweenMax.min.js)                                                           |
+| 15  | 8,845,893  |    13.89 | [cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.css](https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.css)                           |
+| 16  | 8,679,029  |    57.63 | [cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.js](https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.0/cookieconsent.min.js)                             |
+| 17  | 7,958,061  |   217.10 | [cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js)                                                           |
+| 18  | 7,899,886  |   269.58 | [cdnjs.cloudflare.com/ajax/libs/gsap/1.19.0/TweenMax.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/1.19.0/TweenMax.min.js)                                                         |
+| 19  | 7,875,389  |    17.50 | [cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookieconsent.min.js](https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/cookieconsent.min.js)                             |
+| 20  | 7,596,996  |    34.82 | [cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js](https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js)                                               |
+| 21  | 7,349,193  |   203.85 | [cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js)                                                           |
+| 22  | 7,139,963  |   250.18 | [cdnjs.cloudflare.com/ajax/libs/gsap/1.20.2/TweenMax.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/1.20.2/TweenMax.min.js)                                                         |
+| 23  | 6,732,516  |    39.61 | [cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js](https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js)                                     |
+| 24  | 6,622,441  |   234.88 | [cdnjs.cloudflare.com/ajax/libs/gsap/2.0.1/TweenMax.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/2.0.1/TweenMax.min.js)                                                           |
+| 25  | 6,599,382  |   177.13 | [cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js)                                                           |
+| 26  | 6,480,862  |    79.51 | [cdnjs.cloudflare.com/ajax/libs/video.js/5.15.1/video-js.min.css](https://cdnjs.cloudflare.com/ajax/libs/video.js/5.15.1/video-js.min.css)                                               |
+| 27  | 6,378,576  |   225.31 | [cdnjs.cloudflare.com/ajax/libs/gsap/1.20.3/TweenMax.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/1.20.3/TweenMax.min.js)                                                         |
+| 28  | 6,354,519  |    62.23 | [cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.mobile.min.js](https://cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.mobile.min.js)                                       |
+| 29  | 6,353,320  |    43.94 | [cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js](https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js)                                           |
+| 30  | 6,258,637  |   194.53 | [cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js)                                                         |
+| 31  | 5,933,372  |    71.55 | [cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.11/lodash.core.min.js](https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.11/lodash.core.min.js)                                       |
+| 32  | 5,844,752  |    37.46 | [cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js](https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js)                                           |
+| 33  | 5,676,475  |    24.51 | [cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css](https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css)                                             |
+| 34  | 5,476,749  |    38.18 | [cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css](https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css)                                 |
+| 35  | 5,394,334  |   179.45 | [cdnjs.cloudflare.com/ajax/libs/gsap/1.18.2/TweenMax.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.2/TweenMax.min.js)                                                         |
+| 36  | 5,388,241  |   166.34 | [cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js)                                                         |
+| 37  | 5,123,346  |    23.10 | [cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css](https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.0/animate.min.css)                                             |
+| 38  | 5,116,628  |   157.67 | [cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.23.0/polyfill.min.js](https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.23.0/polyfill.min.js)                                     |
+| 39  | 5,108,716  |     5.23 | [cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.css](https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.css)                                           |
+| 40  | 5,016,335  |   139.30 | [cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js)                                                           |
+| 41  | 4,981,688  |   169.79 | [cdnjs.cloudflare.com/ajax/libs/flickity/2.0.10/flickity.pkgd.min.js](https://cdnjs.cloudflare.com/ajax/libs/flickity/2.0.10/flickity.pkgd.min.js)                                       |
+| 42  | 4,919,438  |    70.53 | [cdnjs.cloudflare.com/ajax/libs/gsap/latest/plugins/CSSPlugin.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/latest/plugins/CSSPlugin.min.js)                                       |
+| 43  | 4,901,213  |    46.37 | [cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js](https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js)                         |
+| 44  | 4,815,742  |   168.91 | [cdnjs.cloudflare.com/ajax/libs/gsap/1.20.4/TweenMax.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/1.20.4/TweenMax.min.js)                                                         |
+| 45  | 4,600,074  |    23.33 | [cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js](https://cdnjs.cloudflare.com/ajax/libs/webfont/1.6.28/webfontloader.js)                                                 |
+| 46  | 4,494,685  |    41.57 | [cdnjs.cloudflare.com/ajax/libs/gsap/latest/TweenLite.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/latest/TweenLite.min.js)                                                       |
+| 47  | 4,365,361  |    77.85 | [cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css](https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css)                     |
+| 48  | 4,187,559  |    73.97 | [cdnjs.cloudflare.com/ajax/libs/lodash.js/3.10.0/lodash.min.js](https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.10.0/lodash.min.js)                                                   |
+| 49  | 4,160,807  |    24.52 | [cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css](https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css)                         |
+| 50  | 4,153,209  |   130.00 | [cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.0/TweenMax.min.js)                                                         |
+| 51  | 4,147,212  |    57.38 | [cdnjs.cloudflare.com/ajax/libs/URI.js/1.17.0/URI.js](https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.17.0/URI.js)                                                                       |
+| 52  | 4,147,142  |    52.55 | [cdnjs.cloudflare.com/ajax/libs/most/0.15.0/most.min.js](https://cdnjs.cloudflare.com/ajax/libs/most/0.15.0/most.min.js)                                                                 |
+| 53  | 4,065,235  |     9.25 | [cdnjs.cloudflare.com/ajax/libs/URI.js/1.17.0/punycode.min.js](https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.17.0/punycode.min.js)                                                     |
+| 54  | 4,061,843  |    14.47 | [cdnjs.cloudflare.com/ajax/libs/URI.js/1.17.0/SecondLevelDomains.min.js](https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.17.0/SecondLevelDomains.min.js)                                 |
+| 55  | 4,055,778  |    12.54 | [cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js](https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js)                                         |
+| 56  | 4,051,520  |    60.05 | [cdnjs.cloudflare.com/ajax/libs/mobile-detect/1.4.3/mobile-detect.min.js](https://cdnjs.cloudflare.com/ajax/libs/mobile-detect/1.4.3/mobile-detect.min.js)                               |
+| 57  | 4,020,204  |     4.86 | [cdnjs.cloudflare.com/ajax/libs/URI.js/1.17.0/IPv6.min.js](https://cdnjs.cloudflare.com/ajax/libs/URI.js/1.17.0/IPv6.min.js)                                                             |
+| 58  | 3,942,119  |     8.76 | [cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3/jquery.easing.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.3/jquery.easing.min.js)                                   |
+| 59  | 3,933,325  |   119.60 | [cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js)                                                         |
+| 60  | 3,922,246  |    13.52 | [cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/logo.png](https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/logo.png)                                                     |
+| 61  | 3,914,045  |     9.35 | [cdnjs.cloudflare.com/ajax/libs/gsap/latest/easing/EasePack.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/latest/easing/EasePack.min.js)                                           |
+| 62  | 3,893,509  |     7.65 | [cdnjs.cloudflare.com/ajax/libs/magnific-popup.js/1.1.0/magnific-popup.min.css](https://cdnjs.cloudflare.com/ajax/libs/magnific-popup.js/1.1.0/magnific-popup.min.css)                   |
+| 63  | 3,862,290  |   275.04 | [cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js](https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js)                                               |
+| 64  | 3,624,522  |    56.98 | [cdnjs.cloudflare.com/ajax/libs/gsap/2.0.1/plugins/CSSPlugin.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/2.0.1/plugins/CSSPlugin.min.js)                                         |
+| 65  | 3,600,554  |    20.16 | [cdnjs.cloudflare.com/ajax/libs/postscribe/2.0.8/postscribe.min.js](https://cdnjs.cloudflare.com/ajax/libs/postscribe/2.0.8/postscribe.min.js)                                           |
+| 66  | 3,588,860  |     6.31 | [cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery.lazyload/1.9.1/jquery.lazyload.min.js)                       |
+| 67  | 3,519,854  |    34.67 | [cdnjs.cloudflare.com/ajax/libs/gsap/2.0.1/TweenLite.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/2.0.1/TweenLite.min.js)                                                         |
+| 68  | 3,485,710  |    18.99 | [cdnjs.cloudflare.com/ajax/libs/bxslider/4.1.2/jquery.bxslider.min.js](https://cdnjs.cloudflare.com/ajax/libs/bxslider/4.1.2/jquery.bxslider.min.js)                                     |
+| 69  | 3,467,097  |   126.40 | [cdnjs.cloudflare.com/ajax/libs/gsap/2.1.2/TweenMax.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/2.1.2/TweenMax.min.js)                                                           |
+| 70  | 3,464,259  |    25.83 | [cdnjs.cloudflare.com/ajax/libs/magnific-popup.js/1.1.0/jquery.magnific-popup.min.js](https://cdnjs.cloudflare.com/ajax/libs/magnific-popup.js/1.1.0/jquery.magnific-popup.min.js)       |
+| 71  | 3,404,942  |   109.51 | [cdnjs.cloudflare.com/ajax/libs/gsap/1.17.0/TweenMax.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/1.17.0/TweenMax.min.js)                                                         |
+| 72  | 3,361,872  |     7.67 | [cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.10/cookieconsent.min.js](https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.10/cookieconsent.min.js)                           |
+| 73  | 3,326,148  |   112.33 | [cdnjs.cloudflare.com/ajax/libs/gsap/1.18.5/TweenMax.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.5/TweenMax.min.js)                                                         |
+| 74  | 3,316,595  |     3.77 | [cdnjs.cloudflare.com/ajax/libs/jqueryui-touch-punch/0.2.3/jquery.ui.touch-punch.min.js](https://cdnjs.cloudflare.com/ajax/libs/jqueryui-touch-punch/0.2.3/jquery.ui.touch-punch.min.js) |
+| 75  | 3,201,312  |    94.56 | [cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js)                                                           |
+| 76  | 3,064,550  |    48.51 | [cdnjs.cloudflare.com/ajax/libs/gsap/2.0.2/plugins/CSSPlugin.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/2.0.2/plugins/CSSPlugin.min.js)                                         |
+| 77  | 3,040,584  |     5.75 | [cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.js](https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.js)                                       |
+| 78  | 3,018,823  |    93.06 | [cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js](https://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.min.js)                                                           |
+| 79  | 3,005,303  |    18.96 | [cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css](https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css)                         |
+| 80  | 2,935,716  |    30.10 | [cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.js](https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.js)                                             |
+| 81  | 2,932,030  |   152.74 | [cdnjs.cloudflare.com/ajax/libs/font-awesome/4.3.0/fonts/fontawesome-webfont.woff2](https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.3.0/fonts/fontawesome-webfont.woff2)           |
+| 82  | 2,931,802  |     7.57 | [cdnjs.cloudflare.com/ajax/libs/gsap/2.0.2/easing/EasePack.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/2.0.2/easing/EasePack.min.js)                                             |
+| 83  | 2,930,370  |    31.72 | [cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js](https://cdnjs.cloudflare.com/ajax/libs/OwlCarousel2/2.3.4/owl.carousel.min.js)                                   |
+| 84  | 2,922,995  |     3.78 | [cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/dark-bottom.css](https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.9/dark-bottom.css)                                       |
+| 85  | 2,902,154  |     3.82 | [cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css](https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css)                                             |
+| 86  | 2,882,747  |     3.94 | [cdnjs.cloudflare.com/ajax/libs/js-cookie/2.2.0/js.cookie.min.js](https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.2.0/js.cookie.min.js)                                               |
+| 87  | 2,877,080  |    28.40 | [cdnjs.cloudflare.com/ajax/libs/gsap/2.0.2/TweenLite.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/2.0.2/TweenLite.min.js)                                                         |
+| 88  | 2,796,324  |     1.64 | [cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/6.1.3/bootstrap-slider.js](https://cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/6.1.3/bootstrap-slider.js)                           |
+| 89  | 2,778,153  |    93.21 | [cdnjs.cloudflare.com/ajax/libs/gsap/1.18.4/TweenMax.min.js](https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.4/TweenMax.min.js)                                                         |
+| 90  | 2,761,521  |    10.85 | [cdnjs.cloudflare.com/ajax/libs/headroom/0.9.4/headroom.min.js](https://cdnjs.cloudflare.com/ajax/libs/headroom/0.9.4/headroom.min.js)                                                   |
+| 91  | 2,685,713  |    48.93 | [cdnjs.cloudflare.com/ajax/libs/rollbar.js/2.4.6/rollbar.min.js](https://cdnjs.cloudflare.com/ajax/libs/rollbar.js/2.4.6/rollbar.min.js)                                                 |
+| 92  | 2,676,314  |     3.35 | [cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css](https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css)                               |
+| 93  | 2,666,160  |    17.95 | [cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js](https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js)                                           |
+| 94  | 2,612,687  |    24.24 | [cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css](https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css)                                             |
+| 95  | 2,586,644  |    82.20 | [cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js](https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js)                                     |
+| 96  | 2,571,054  |    18.31 | [cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js](https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js)                                                     |
+| 97  | 2,513,520  |     8.67 | [cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.10/logo.png](https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/1.0.10/logo.png)                                                   |
+| 98  | 2,506,207  |    44.66 | [cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js](https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js)                                                               |
+| 99  | 2,498,933  |     1.38 | [cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/6.1.3/css/bootstrap-slider.css](https://cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/6.1.3/css/bootstrap-slider.css)                 |
+| 100 | 2,480,059  |     7.73 | [cdnjs.cloudflare.com/ajax/libs/Swiper/3.4.2/css/swiper.min.css](https://cdnjs.cloudflare.com/ajax/libs/Swiper/3.4.2/css/swiper.min.css)                                                 |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Welcome to the cf-stats repository, the store of the monthly usage stats reports
 These reports are created by cdnjs with data provided by Cloudflare.
 
 ## 2019
+* [May 2019](2019/cdnjs_May_2019.md)
 * [April 2019](2019/cdnjs_April_2019.md)
 * [March 2019](2019/cdnjs_March_2019.md)
 * [February 2019](2019/cdnjs_February_2019.md)

--- a/table.py
+++ b/table.py
@@ -1,0 +1,84 @@
+"""
+A quick script to parse the top 100 requests stats
+dumps that Cloudflare give us into a clean table.
+"""
+import requests
+import re
+import beautifultable
+from typing import List, Dict, Union
+
+def generateRegex(order: List[str]) -> str:
+    final = []
+    patterns = {
+        "requests": "(?P<requests>\d+)",
+        "resources": "(?P<resource>\S+)",
+        "bandwidth": "(?P<bandwidth>\d+(?:\.\d+)?)"
+    }
+    for item in order:
+        if item in patterns:
+            final.append(patterns[item])
+    final = "^\s*" + "\s*".join(final) + "\s*$"
+    return final
+
+def parseRaw(url: str, regex: str) -> List[Dict[str, Union[int, float, str]]]:
+    # Get the raw dump from the url
+    raw = requests.get(url).text
+    data = []
+
+    # Iterate over each line of the dump
+    for line in raw.split("\n"):
+        try:
+            # Attempt to find the components through regex
+            x = re.search(regex, line)
+            y = x.groupdict()
+
+            # Ensure correct datatypes
+            y["requests"] = int(y["requests"])
+            y["bandwidth"] = float(y["bandwidth"])
+            data.append(y)
+        except:
+            continue
+    return data
+
+def formatData(data: List[Dict[str, Union[int, float, str]]]) -> str:
+    # Create the header
+    header = beautifultable.BeautifulTable(max_width=1000, default_alignment=beautifultable.ALIGN_LEFT)
+    header.set_style(beautifultable.STYLE_MARKDOWN)
+    header.column_headers = ["#", "Requests", "Bandwidth", "cdnjs Resource URL"]
+    header.append_row(["", "", "", ""])
+    
+    # Create the base table
+    table = beautifultable.BeautifulTable(max_width=1000, default_alignment=beautifultable.ALIGN_LEFT)
+    table.set_style(beautifultable.STYLE_MARKDOWN)
+    table.detect_numerics = False  # This breaks the formatting
+    
+    # Sort the data
+    data = sorted(data, key=lambda x: x["requests"], reverse=True)
+
+    # Generate the table
+    for i, row in enumerate(data):
+        try:
+            table.append_row([
+                "{:,}".format(i+1),
+                "{:,}".format(row["requests"]),
+                "{:,.2f}".format(row["bandwidth"]),
+                "[{0}](https://{0})".format(row["resource"])
+            ])
+        except:
+            continue
+
+    # Export header + table
+    table.column_alignments[2] = beautifultable.ALIGN_RIGHT
+    header = str(header)
+    table = str(table)
+    return header[:header.rfind("\n")] + "\n" + table
+
+def tableFromRaw(url: str, order: List[str]) -> str:
+    regex = generateRegex(order)
+    data = parseRaw(url, regex)
+    table = formatData(data)
+    return table
+
+print(tableFromRaw("", ["requests", "resources", "bandwidth"]))
+        
+    


### PR DESCRIPTION
Brings in the May 2019 stats as well as a python script to convert the cf raw dumps into clean markdown tables.